### PR TITLE
feat: use hass.formatEntityState for states

### DIFF
--- a/dist/lib-venus.js
+++ b/dist/lib-venus.js
@@ -20,10 +20,7 @@ let editorOpen = false;
 /********************************************************/
 function formatEntityWithUnit(hass) {
     return (entityId) => {
-        // Look up entity state from hass.states using the entity ID
         const stateObj = hass.states[entityId];
-
-        // Handle null/undefined state - return empty string for display
         if (!stateObj) {
             return '';
         }
@@ -33,9 +30,8 @@ function formatEntityWithUnit(hass) {
 
         // If formatted value ends with the unit, ensure it is styled correctly.
         if (unit && formattedValue.endsWith(unit)) {
-          // Extract value with locale-specific spacing preserved
-          const valueWithSpace = formattedValue.slice(0, -unit.length);
-          return `${valueWithSpace}<div class="boxUnit">${unit}</div>`;
+          const valueMinusUnit = formattedValue.slice(0, -unit.length);
+          return `${valueMinusUnit}<div class="boxUnit">${unit}</div>`;
         }
 
         // Return formatted value as-is

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "Venus OS Dashboard",
-  "homeassistant": "2023.1.0",
+  "homeassistant": "2023.9",
   "render_readme": true,
   "content_in_root": false
 }


### PR DESCRIPTION
Updated the card to use [`hass.formatEntityState`](https://developers.home-assistant.io/docs/frontend/data#entity-state-formatting) to format the entity state using the configured preferences (such as precision). 

Updated the minimum required HA version to 2023.9 as that is when `hass.formatEntityState` was introduced.

Fixes #5 and any other situations where the entity state would display differently in this card compared to elsewhere in Home Assistant.